### PR TITLE
Updating regex logic for new eiopa links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = ['numpy',
-                'pandas',
+                'pandas<2.0.0',
                 'openpyxl==3.1.0',
                 'configparser',
                 'twine',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = ['numpy',
-                'pandas<2.0.0',
+                'pandas',
                 'openpyxl==3.1.0',
                 'configparser',
                 'twine',

--- a/solvency2_data/eiopa_data.py
+++ b/solvency2_data/eiopa_data.py
@@ -6,6 +6,7 @@ Downloads rfr and stores in sqlite database for future reference
 """
 import datetime
 import os
+import re
 import zipfile
 import pandas as pd
 import urllib
@@ -96,10 +97,20 @@ def download_EIOPA_rates(url: str, ref_date: str) -> dict:
 
     name_excelfile = "EIOPA_RFR_" + reference_date + "_Term_Structures" + ".xlsx"
     name_excelfile_spreads = "EIOPA_RFR_" + reference_date + "_PD_Cod" + ".xlsx"
+    # Making file paths string insensitve via regex
+    re_rfr = re.compile(f"(?i:{name_excelfile})")
+    re_spreads = re.compile(f"(?i:{name_excelfile_spreads})")
 
     with zipfile.ZipFile(zip_file) as zipobj:
-        zipobj.extract(name_excelfile, raw_folder)
-        zipobj.extract(name_excelfile_spreads, raw_folder)
+        for file in zipobj.namelist():
+            res_rfr = re_rfr.search(file)
+            res_spreads = re_spreads.search(file)
+            if res_rfr:
+                rfr_file = res_rfr.group(0)
+                zipobj.extract(rfr_file, raw_folder)
+            if res_spreads:
+                spreads_file = res_spreads.group(0)
+                zipobj.extract(spreads_file, raw_folder)
     return {
         "rfr": os.path.join(raw_folder, name_excelfile),
         "meta": os.path.join(raw_folder, name_excelfile),

--- a/solvency2_data/eiopa_data.py
+++ b/solvency2_data/eiopa_data.py
@@ -260,9 +260,8 @@ def extract_sym_adj(sym_adj_filepath: str, ref_date: str) -> pd.DataFrame:
         nrows=1,
         skiprows=7,
         header=None,
-        squeeze=True,
         names=["ref_date", "sym_adj"],
-    )
+    ).squeeze('columns')
 
     input_ref = ref_date
     ref_check = df.at[0, "ref_date"].strftime("%Y-%m-%d")
@@ -400,6 +399,7 @@ def refresh():
 
     """
     dr = pd.date_range(date(2016, 1, 31), date.today(), freq="M")
+    # dr = pd.date_range(date(2021, 11, 30), date.today(), freq="M")
     for ref_date in dr:
         for data_type in ["rfr", "meta", "spreads", "govies", "sym_adj"]:
             df = get(ref_date.date(), data_type)

--- a/solvency2_data/scraping.py
+++ b/solvency2_data/scraping.py
@@ -10,6 +10,7 @@ import requests
 import datetime
 urls_dict = {
     "rfr": [
+        "https://www.eiopa.europa.eu/tools-and-data/risk-free-interest-rate-term-structures/risk-free-rate-previous-releases-and-preparatory-phase_en",
         "https://www.eiopa.europa.eu/tools-and-data/risk-free-interest-rate-term-structures_en",
         "https://www.eiopa.europa.eu/risk-free-rate-previous-releases-and-preparatory-phase",
     ],
@@ -61,7 +62,6 @@ def lookthrough_redirect(url: str) -> str:
     return file_url
 
 
-
 def eiopa_link(ref_date: str, data_type: str = "rfr") -> str:
     """
     This returns the link for downloading the selected type of data for a given date
@@ -87,17 +87,21 @@ def eiopa_link(ref_date: str, data_type: str = "rfr") -> str:
     data_type = data_type_remap.get(data_type, data_type)
     urls = urls_dict.get(data_type)
     # Change format of ref_date string for EIOPA Excel files from YYYY-mm-dd to YYYYmmdd:
-    print(ref_date)
     reference_date = ref_date.replace('-', '')
     ref_date_datetime = datetime.datetime.strptime(ref_date, '%Y-%m-%d')
+    str_year = ref_date_datetime.strftime("%Y")
+    str_month = ref_date_datetime.strftime("%B").lower()
     if data_type == "rfr":
         # eiopa uses two naming conventions for the files
-        filename1 = ".*"+ref_date_datetime.strftime("%B%%20%Y")+"(%E2%80%8B)?"
-        filename2 = ".*EIOPA_RFR_" + reference_date + ".zip"
-        r = re.compile(filename1+"|"+filename2)
+        # filename1 = ".*"+ref_date_datetime.strftime("%B%%20%Y")+"(%E2%80%8B)?"
+        # filename2 = ".*EIOPA_RFR_" + reference_date + ".zip"
+        # r = re.compile(filename1+"|"+filename2)
+        r = re.compile(".*(?i:filename=)"
+                       + "(?i:" + str_month + ")"
+                       + "(?:[-, _]|%20)" + str_year
+                       + ".*"
+        )
     elif data_type == "sym_adj":
-        str_year = ref_date_datetime.strftime("%Y")
-        str_month = ref_date_datetime.strftime("%B").lower()
         # Regex to find the file :
         # ._ required for ._march_2019
         # Only matches on first 3 letters of months since some mis-spellings

--- a/solvency2_data/scraping.py
+++ b/solvency2_data/scraping.py
@@ -91,7 +91,6 @@ def eiopa_link(ref_date: str, data_type: str = "rfr") -> str:
     ref_date_datetime = datetime.datetime.strptime(ref_date, '%Y-%m-%d')
     str_year = ref_date_datetime.strftime("%Y")
     str_month = ref_date_datetime.strftime("%B").lower()
-    print(ref_date)
     if data_type == "rfr":
         # eiopa uses two naming conventions for the files
         filename1 = ".*(?i:filename=)(?:%E2%80%8B)?"\

--- a/solvency2_data/scraping.py
+++ b/solvency2_data/scraping.py
@@ -71,9 +71,9 @@ def eiopa_link(ref_date: str, data_type: str = "rfr") -> str:
 
     from datetime import date
     import pandas as pd
-    dr = pd.date_range(date(2016,1,31), date(2021,7,31), freq='M')
-    rfr_links = {i.strftime('%Y%m%d'): eiopa_link(i) for i in dr}
-    sym_adj_links = {i.strftime('%Y%m%d'): eiopa_link(i, 'sym_adj') for i in dr}
+    dr = pd.date_range(date(2016,1,31), date(2023,5,31), freq='M')
+    rfr_links = {i.strftime('%Y%m%d'): eiopa_link(i.strftime('%Y-%m-%d')) for i in dr}
+    sym_adj_links = {i.strftime('%Y%m%d'): eiopa_link(i.strftime('%Y-%m-%d'), 'sym_adj') for i in dr}
 
     Args:
         ref_date: reference date
@@ -91,16 +91,16 @@ def eiopa_link(ref_date: str, data_type: str = "rfr") -> str:
     ref_date_datetime = datetime.datetime.strptime(ref_date, '%Y-%m-%d')
     str_year = ref_date_datetime.strftime("%Y")
     str_month = ref_date_datetime.strftime("%B").lower()
+    print(ref_date)
     if data_type == "rfr":
         # eiopa uses two naming conventions for the files
-        # filename1 = ".*"+ref_date_datetime.strftime("%B%%20%Y")+"(%E2%80%8B)?"
-        # filename2 = ".*EIOPA_RFR_" + reference_date + ".zip"
-        # r = re.compile(filename1+"|"+filename2)
-        r = re.compile(".*(?i:filename=)"
-                       + "(?i:" + str_month + ")"
-                       + "(?:[-, _]|%20)" + str_year
-                       + ".*"
-        )
+        filename1 = ".*(?i:filename=)(?:%E2%80%8B)?"\
+                    + "(?i:" + str_month + ")"\
+                    + "(?:[-, _]|%20)" + str_year\
+                    + ".*"".*"
+        filename2 = ".*EIOPA_RFR_" + reference_date + ".zip"
+        r = re.compile(filename1+"|"+filename2)
+
     elif data_type == "sym_adj":
         # Regex to find the file :
         # ._ required for ._march_2019
@@ -113,7 +113,7 @@ def eiopa_link(ref_date: str, data_type: str = "rfr") -> str:
                        + str(len(str_month) - 3)
                        + "}(?:[-, _]|%20)"
                        + str_year
-                       + "(?:.xlsx|$)"
+                       + "(?:_[0-9]{0,1})?(?:.xlsx|$)"
         )
 
     valid_link = get_links(urls, r)


### PR DESCRIPTION
@wjwillemse
This is a partial fix i.e. the error that was reported shouldn't appear anymore.
Still have an issue now with the EIOPA links for the rfr from 2016-09.

If i can I'll try and update the regex for this one too.

~~There's also a problem using pandas 2.0 as read_excel(squeeze=True) has been deprecated.~~